### PR TITLE
Add User DTOs, mapper and registration endpoints

### DIFF
--- a/src/main/java/com/popcornpicks/controllers/UserController.java
+++ b/src/main/java/com/popcornpicks/controllers/UserController.java
@@ -1,0 +1,64 @@
+package com.popcornpicks.controllers;
+
+import com.popcornpicks.dto.UserRegistrationRequest;
+import com.popcornpicks.dto.UserResponse;
+import com.popcornpicks.exceptions.EmailAlreadyExistsException;
+import com.popcornpicks.mapper.UserMapper;
+import com.popcornpicks.models.User;
+import com.popcornpicks.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/v1")
+public class UserController {
+
+    private final UserService userService;
+    private final UserMapper userMapper;
+
+    @Autowired
+    public UserController(UserService userService,
+                          UserMapper userMapper) {
+        this.userService = userService;
+        this.userMapper = userMapper;
+    }
+
+    /** Register a new user. Returns 201 or 409 if email is taken. */
+    @PostMapping("/auth/register")
+    public ResponseEntity<UserResponse> register(
+            @RequestBody UserRegistrationRequest registrationRequest) {
+
+        try {
+            User toCreate = userMapper.toEntity(registrationRequest);
+            User created = userService.register(toCreate);
+            UserResponse response = userMapper.toDto(created);
+            return new ResponseEntity<>(response, HttpStatus.CREATED);
+
+        } catch (EmailAlreadyExistsException ex) {
+            // Convert our service exception into a 409 response
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT, ex.getMessage(), ex
+            );
+        }
+    }
+
+    /** Retrieve a user by their ID. Returns 200 or 404 if not found. */
+    @GetMapping("/users/{id}")
+    public ResponseEntity<UserResponse> getUserById(@PathVariable Long id) {
+        Optional<User> userOpt = userService.findById(id);
+        if (userOpt.isPresent()) {
+            UserResponse response = userMapper.toDto(userOpt.get());
+            return ResponseEntity.ok(response);
+        } else {
+            throw new ResponseStatusException(
+                    HttpStatus.NOT_FOUND,
+                    "User not found with id " + id
+            );
+        }
+    }
+}

--- a/src/main/java/com/popcornpicks/dto/UserMapper.java
+++ b/src/main/java/com/popcornpicks/dto/UserMapper.java
@@ -1,0 +1,31 @@
+package com.popcornpicks.mapper;
+
+import com.popcornpicks.dto.UserRegistrationRequest;
+import com.popcornpicks.dto.UserResponse;
+import com.popcornpicks.models.User;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+
+@Component
+public class UserMapper {
+
+    /** Convert registration payload into a User entity.
+     *  Assigns the default role “USER”. */
+    public User toEntity(UserRegistrationRequest req) {
+        User user = new User();
+        user.setEmail(req.getEmail());
+        user.setPassword(req.getPassword());
+        user.setRoles(Collections.singleton("USER"));
+        return user;
+    }
+
+    /** Convert User entity into a response DTO. */
+    public UserResponse toDto(User user) {
+        return new UserResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getRoles()
+        );
+    }
+}

--- a/src/main/java/com/popcornpicks/dto/UserRegistrationRequest.java
+++ b/src/main/java/com/popcornpicks/dto/UserRegistrationRequest.java
@@ -1,0 +1,27 @@
+package com.popcornpicks.dto;
+
+public class UserRegistrationRequest {
+    private String email;
+    private String password;
+
+    public UserRegistrationRequest() { }
+
+    public UserRegistrationRequest(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/popcornpicks/dto/UserResponse.java
+++ b/src/main/java/com/popcornpicks/dto/UserResponse.java
@@ -1,0 +1,38 @@
+package com.popcornpicks.dto;
+
+import java.util.Set;
+
+public class UserResponse {
+    private Long id;
+    private String email;
+    private Set<String> roles;
+
+    public UserResponse() { }
+
+    public UserResponse(Long id, String email, Set<String> roles) {
+        this.id = id;
+        this.email = email;
+        this.roles = roles;
+    }
+
+    public Long getId() {
+        return id;
+    }
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public Set<String> getRoles() {
+        return roles;
+    }
+    public void setRoles(Set<String> roles) {
+        this.roles = roles;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=PopcornPicks
 
 # datasource PostgreSQl
 spring.sql.init.platform=postgres
-spring.datasource.url=jdbc:postgresql://localhost:5432/television
+spring.datasource.url=jdbc:postgresql://localhost:5432/popcornpicks
 spring.datasource.username=postgres
 spring.datasource.password=password
 spring.datasource.driver-class-name=org.postgresql.Driver


### PR DESCRIPTION
Defined UserRegistrationRequest and UserResponse DTOs

Created UserMapper to convert between entity and DTOs, assigning a default USER role

Added EmailAlreadyExistsException for duplicate-email checks

Built UserServiceImpl.register() to enforce unique emails and persist users

Exposed POST /api/v1/auth/register and GET /api/v1/users/{id} in UserController

Verified database schema auto-creation and successful manual testing via Postman