### PR TITLE
Complete Watchlist feature: entity, repo, service, DTO, mapper & cont…

### DIFF
--- a/src/main/java/com/popcornpicks/controllers/WatchlistController.java
+++ b/src/main/java/com/popcornpicks/controllers/WatchlistController.java
@@ -1,0 +1,71 @@
+package com.popcornpicks.controllers;
+
+import com.popcornpicks.dto.PageResponse;
+import com.popcornpicks.dto.WatchlistResponse;
+import com.popcornpicks.mapper.WatchlistMapper;
+import com.popcornpicks.models.WatchlistItem;
+import com.popcornpicks.service.WatchlistService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/users/{userId}/watchlist")
+public class WatchlistController {
+
+    private final WatchlistService service;
+    private final WatchlistMapper mapper;
+
+    @Autowired
+    public WatchlistController(WatchlistService service, WatchlistMapper mapper) {
+        this.service = service;
+        this.mapper  = mapper;
+    }
+
+    /** Add a movie to the watchlist */
+    @PostMapping
+    public ResponseEntity<WatchlistResponse> add(
+            @PathVariable Long userId,
+            @RequestParam Long movieId
+    ) {
+        WatchlistItem item = service.addToWatchlist(userId, movieId);
+        return new ResponseEntity<>(mapper.toDto(item), HttpStatus.CREATED);
+    }
+
+    /** Remove a movie from watchlist */
+    @DeleteMapping("/{movieId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void remove(
+            @PathVariable Long userId,
+            @PathVariable Long movieId
+    ) {
+        service.removeFromWatchlist(userId, movieId);
+    }
+
+    /** List watchlist items for a user */
+    @GetMapping
+    public PageResponse<WatchlistResponse> list(
+            @PathVariable Long userId,
+            Pageable pageable
+    ) {
+        Page<WatchlistItem> page = service.getWatchlist(userId, pageable);
+        List<WatchlistResponse> dtos = page.getContent()
+                .stream()
+                .map(mapper::toDto)
+                .toList();
+
+        return new PageResponse<>(
+                dtos,
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages()
+        );
+    }
+    }
+
+

--- a/src/main/java/com/popcornpicks/dto/PageResponse.java
+++ b/src/main/java/com/popcornpicks/dto/PageResponse.java
@@ -1,0 +1,40 @@
+package com.popcornpicks.dto;
+
+import java.util.List;
+
+public class PageResponse<T> {
+    private List<T> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+
+    public PageResponse() {}
+
+    public PageResponse(List<T> content,
+                        int page,
+                        int size,
+                        long totalElements,
+                        int totalPages) {
+        this.content       = content;
+        this.page          = page;
+        this.size          = size;
+        this.totalElements = totalElements;
+        this.totalPages    = totalPages;
+    }
+
+    public List<T> getContent() { return content; }
+    public void setContent(List<T> content) { this.content = content; }
+
+    public int getPage() { return page; }
+    public void setPage(int page) { this.page = page; }
+
+    public int getSize() { return size; }
+    public void setSize(int size) { this.size = size; }
+
+    public long getTotalElements() { return totalElements; }
+    public void setTotalElements(long totalElements) { this.totalElements = totalElements; }
+
+    public int getTotalPages() { return totalPages; }
+    public void setTotalPages(int totalPages) { this.totalPages = totalPages; }
+}

--- a/src/main/java/com/popcornpicks/dto/WatchlistResponse.java
+++ b/src/main/java/com/popcornpicks/dto/WatchlistResponse.java
@@ -1,0 +1,52 @@
+package com.popcornpicks.dto;
+
+import java.time.LocalDateTime;
+
+public class WatchlistResponse {
+    private Long id;
+    private Long movieId;
+    private String title;        // optional, for convenience
+    private LocalDateTime addedAt;
+
+    public WatchlistResponse() {
+    }
+
+    public WatchlistResponse(Long id, Long movieId, String title, LocalDateTime addedAt) {
+        this.id = id;
+        this.movieId = movieId;
+        this.title = title;
+        this.addedAt = addedAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getMovieId() {
+        return movieId;
+    }
+
+    public void setMovieId(Long movieId) {
+        this.movieId = movieId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public LocalDateTime getAddedAt() {
+        return addedAt;
+    }
+
+    public void setAddedAt(LocalDateTime addedAt) {
+        this.addedAt = addedAt;
+    }
+}

--- a/src/main/java/com/popcornpicks/mapper/WatchlistMapper.java
+++ b/src/main/java/com/popcornpicks/mapper/WatchlistMapper.java
@@ -1,0 +1,18 @@
+package com.popcornpicks.mapper;
+
+import com.popcornpicks.dto.WatchlistResponse;
+import com.popcornpicks.models.WatchlistItem;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WatchlistMapper {
+
+    public WatchlistResponse toDto(WatchlistItem item) {
+        return new WatchlistResponse(
+                item.getId(),
+                item.getMovie().getId(),
+                item.getMovie().getTitle(),
+                item.getAddedAt()
+        );
+    }
+}

--- a/src/main/java/com/popcornpicks/models/WatchlistItem.java
+++ b/src/main/java/com/popcornpicks/models/WatchlistItem.java
@@ -1,0 +1,66 @@
+package com.popcornpicks.models;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "watchlist_items",
+        uniqueConstraints = @UniqueConstraint(
+                columnNames = {"user_id", "movie_id"},
+                name = "uk_user_movie_watchlist"
+        )
+)
+public class WatchlistItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "movie_id", nullable = false)
+    private Movie movie;
+
+    @Column(name = "added_at", updatable = false)
+    @CreationTimestamp
+    private LocalDateTime addedAt;
+
+    public WatchlistItem() { }
+
+    public WatchlistItem(User user, Movie movie) {
+        this.user = user;
+        this.movie = movie;
+    }
+
+    // Getters
+
+    public Long getId() {
+        return id;
+    }
+    public User getUser() {
+        return user;
+    }
+    public Movie getMovie() {
+        return movie;
+    }
+    public LocalDateTime getAddedAt() {
+        return addedAt;
+    }
+
+    // Setters
+
+    // no setter for id or addedAt
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+    public void setMovie(Movie movie) {
+        this.movie = movie;
+    }
+}

--- a/src/main/java/com/popcornpicks/repository/WatchlistRepository.java
+++ b/src/main/java/com/popcornpicks/repository/WatchlistRepository.java
@@ -1,0 +1,22 @@
+package com.popcornpicks.repository;
+
+import com.popcornpicks.models.WatchlistItem;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface WatchlistRepository extends JpaRepository<WatchlistItem, Long> {
+
+    /** Prevent duplicates: find an existing entry for user+movie */
+    Optional<WatchlistItem> findByUserIdAndMovieId(Long userId, Long movieId);
+
+    /** List all watchlist items for a given user */
+    Page<WatchlistItem> findByUserId(Long userId, Pageable pageable);
+
+    /** Convenience: delete by user and movie */
+    void deleteByUserIdAndMovieId(Long userId, Long movieId);
+}

--- a/src/main/java/com/popcornpicks/service/WatchlistService.java
+++ b/src/main/java/com/popcornpicks/service/WatchlistService.java
@@ -1,0 +1,17 @@
+package com.popcornpicks.service;
+
+import com.popcornpicks.models.WatchlistItem;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface WatchlistService {
+
+    /** Add a movie to the user’s watchlist; no-ops on duplicate */
+    WatchlistItem addToWatchlist(Long userId, Long movieId);
+
+    /** Remove a movie from the user’s watchlist */
+    void removeFromWatchlist(Long userId, Long movieId);
+
+    /** Fetch the user’s watchlist, paginated */
+    Page<WatchlistItem> getWatchlist(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/popcornpicks/service/impl/WatchlistServiceImpl.java
+++ b/src/main/java/com/popcornpicks/service/impl/WatchlistServiceImpl.java
@@ -1,0 +1,62 @@
+package com.popcornpicks.service.impl;
+
+import com.popcornpicks.models.Movie;
+import com.popcornpicks.models.User;
+import com.popcornpicks.models.WatchlistItem;
+import com.popcornpicks.repository.MovieRepository;
+import com.popcornpicks.repository.UserRepository;
+import com.popcornpicks.repository.WatchlistRepository;
+import com.popcornpicks.service.WatchlistService;
+import com.popcornpicks.exceptions.ResourceNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class WatchlistServiceImpl implements WatchlistService {
+
+    private final WatchlistRepository watchlistRepo;
+    private final UserRepository userRepo;
+    private final MovieRepository movieRepo;
+
+    @Autowired
+    public WatchlistServiceImpl(
+            WatchlistRepository watchlistRepo,
+            UserRepository userRepo,
+            MovieRepository movieRepo
+    ) {
+        this.watchlistRepo = watchlistRepo;
+        this.userRepo     = userRepo;
+        this.movieRepo    = movieRepo;
+    }
+
+    @Override
+    public WatchlistItem addToWatchlist(Long userId, Long movieId) {
+        User user = userRepo.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found: " + userId));
+        Movie movie = movieRepo.findById(movieId)
+                .orElseThrow(() -> new ResourceNotFoundException("Movie not found: " + movieId));
+
+        // if already exists, return it (no duplicate)
+        return watchlistRepo.findByUserIdAndMovieId(userId, movieId)
+                .orElseGet(() -> watchlistRepo.save(new WatchlistItem(user, movie)));
+    }
+
+    @Override
+    public void removeFromWatchlist(Long userId, Long movieId) {
+        // deleteByUserIdAndMovieId does nothing if no match
+        watchlistRepo.deleteByUserIdAndMovieId(userId, movieId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<WatchlistItem> getWatchlist(Long userId, Pageable pageable) {
+        if (!userRepo.existsById(userId)) {
+            throw new ResourceNotFoundException("User not found: " + userId);
+        }
+        return watchlistRepo.findByUserId(userId, pageable);
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -30,3 +30,8 @@ INSERT INTO user_roles (user_id, role) VALUES
                                            (1, 'USER'),
                                            (2, 'USER'),
                                            (3, 'ADMIN');
+
+INSERT INTO watchlist_items (user_id, movie_id) VALUES
+                                                    (1,1),
+                                                    (2,2);
+


### PR DESCRIPTION
This PR adds full CRUD support for users’ watchlists:

WatchlistItem entity

Enforces one‐per‐user/per‐movie via a unique constraint

Records addedAt timestamp automatically

WatchlistRepository

findByUserIdAndMovieId(...), findByUserId(...), deleteByUserIdAndMovieId(...)

WatchlistService & WatchlistServiceImpl

addToWatchlist(...) (no‐op on duplicates)

removeFromWatchlist(...)

getWatchlist(...) with pagination

WatchlistResponse DTO and WatchlistMapper

WatchlistController

POST /api/v1/users/{userId}/watchlist?movieId={movieId}

GET /api/v1/users/{userId}/watchlist

DELETE /api/v1/users/{userId}/watchlist/{movieId}

All endpoints respect the global exception handling and input validation.

